### PR TITLE
refactor: expose registration service

### DIFF
--- a/pkg/whatsapp/client.go
+++ b/pkg/whatsapp/client.go
@@ -114,7 +114,5 @@ func (c *Client) Do(ctx context.Context, req *http.Request) (*http.Response, err
 	return c.do(ctx, req)
 }
 func (c *Client) RegistrationService() *services.RegistrationService {
-	return services.NewRegistrationService(
-		graph.NewRegistrationAPI(c.httpDoer, c.tokenProvider, c.version, c.phoneNumberID),
-	)
+	return c.Registration
 }

--- a/pkg/whatsapp/services/registration_service_test.go
+++ b/pkg/whatsapp/services/registration_service_test.go
@@ -95,7 +95,7 @@ func TestRegistration_ErrorGraphPayload(t *testing.T) {
 	defer ts.Close()
 
 	c := newRegClient(t, ts.URL)
-	svc := services.NewRegistrationService(c.RegistrationService().API())
+	svc := services.NewRegistrationService(c.Registration.API())
 
 	_, err := svc.Register(context.Background(), domain.RegisterParams{Pin: ptr("000000")})
 	if err == nil {


### PR DESCRIPTION
## Summary
- reuse existing registration service instance
- replace RegistrationService() call sites with direct field access
