### PR TITLE
test: add coverage for graph transport

### DIFF
--- a/pkg/whatsapp/transport/graph/endpoints_test.go
+++ b/pkg/whatsapp/transport/graph/endpoints_test.go
@@ -1,0 +1,35 @@
+package graph
+
+import "testing"
+
+func TestBuildURLAndEndpoints(t *testing.T) {
+	base := "https://graph.example.com"
+	version := "v1"
+	phoneID := "123"
+	wabaID := "waba"
+
+	if got := buildURL(base, version, "a", "b"); got != "https://graph.example.com/v1/a/b" {
+		t.Fatalf("buildURL unexpected: %s", got)
+	}
+
+	cases := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"messages", MessagesEndpoint(base, version, phoneID), "https://graph.example.com/v1/123/messages"},
+		{"phoneNumbersList", PhoneNumbersListEndpoint(base, version, wabaID), "https://graph.example.com/v1/waba/phone_numbers"},
+		{"phoneNumberGet", PhoneNumberGetEndpoint(base, version, phoneID), "https://graph.example.com/v1/123"},
+		{"register", RegisterEndpoint(base, version, phoneID), "https://graph.example.com/v1/123/register"},
+		{"deregister", DeregisterEndpoint(base, version, phoneID), "https://graph.example.com/v1/123/deregister"},
+		{"requestCode", RequestCodeEndpoint(base, version, phoneID), "https://graph.example.com/v1/123/request_code"},
+		{"verifyCode", VerifyCodeEndpoint(base, version, phoneID), "https://graph.example.com/v1/123/verify_code"},
+		{"twoFactor", TwoFactorEndpoint(base, version, phoneID), "https://graph.example.com/v1/123"},
+	}
+
+	for _, tt := range cases {
+		if tt.got != tt.want {
+			t.Errorf("%s: got %s, want %s", tt.name, tt.got, tt.want)
+		}
+	}
+}

--- a/pkg/whatsapp/transport/graph/messages_api_test.go
+++ b/pkg/whatsapp/transport/graph/messages_api_test.go
@@ -1,0 +1,54 @@
+package graph
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	portstesting "github.com/diegoyosiura/whatsapp-sdk-go/internal/testutils/whatsapp/ports"
+)
+
+func TestNewSendTextHTTPRequest(t *testing.T) {
+	ctx := context.Background()
+	payload := SendTextRequest{MessagingProduct: "whatsapp", To: "123", Type: "text"}
+	payload.Text.Body = "hi"
+	tp := &portstesting.FakeTokenProvider{TokenValue: "tok"}
+	req, err := NewSendTextHTTPRequest(ctx, DefaultBaseURL, "v1", "pn", payload, tp)
+	if err != nil {
+		t.Fatalf("NewSendTextHTTPRequest error: %v", err)
+	}
+	if req.Method != http.MethodPost {
+		t.Fatalf("expected POST got %s", req.Method)
+	}
+	if req.URL.String() != MessagesEndpoint(DefaultBaseURL, "v1", "pn") {
+		t.Fatalf("unexpected url %s", req.URL.String())
+	}
+	if got := req.Header.Get("Authorization"); got != "Bearer tok" {
+		t.Fatalf("auth header %q", got)
+	}
+	b, _ := io.ReadAll(req.Body)
+	if !strings.Contains(string(b), "\"hi\"") {
+		t.Fatalf("body not encoded: %s", string(b))
+	}
+	rc, err := req.GetBody()
+	if err != nil {
+		t.Fatalf("GetBody error: %v", err)
+	}
+	b2, _ := io.ReadAll(rc)
+	if string(b2) != string(b) {
+		t.Fatalf("GetBody mismatch")
+	}
+}
+
+func TestNewSendTextHTTPRequestTokenError(t *testing.T) {
+	ctx := context.Background()
+	payload := SendTextRequest{MessagingProduct: "whatsapp", To: "123", Type: "text"}
+	tp := &portstesting.FakeTokenProvider{Err: fmt.Errorf("no token")}
+	_, err := NewSendTextHTTPRequest(ctx, DefaultBaseURL, "v1", "pn", payload, tp)
+	if err == nil || !strings.Contains(err.Error(), "token:") {
+		t.Fatalf("expected token error, got %v", err)
+	}
+}

--- a/pkg/whatsapp/transport/graph/phone_numbers_api_test.go
+++ b/pkg/whatsapp/transport/graph/phone_numbers_api_test.go
@@ -1,0 +1,32 @@
+package graph
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestPhoneNumbersRequests(t *testing.T) {
+	ctx := context.Background()
+	req, err := NewPhoneNumbersListRequest(ctx, DefaultBaseURL, "v1", "waba")
+	if err != nil {
+		t.Fatalf("list request err: %v", err)
+	}
+	if req.Method != http.MethodGet || req.URL.String() != PhoneNumbersListEndpoint(DefaultBaseURL, "v1", "waba") {
+		t.Fatalf("unexpected request: %s %s", req.Method, req.URL.String())
+	}
+	if req.Header.Get("Accept") != "application/json" {
+		t.Fatalf("missing accept header")
+	}
+
+	req2, err := NewPhoneNumberGetRequest(ctx, DefaultBaseURL, "v1", "pn")
+	if err != nil {
+		t.Fatalf("get request err: %v", err)
+	}
+	if req2.Method != http.MethodGet || req2.URL.String() != PhoneNumberGetEndpoint(DefaultBaseURL, "v1", "pn") {
+		t.Fatalf("unexpected request2: %s %s", req2.Method, req2.URL.String())
+	}
+	if req2.Header.Get("Accept") != "application/json" {
+		t.Fatalf("missing accept header on req2")
+	}
+}

--- a/pkg/whatsapp/transport/graph/phone_test.go
+++ b/pkg/whatsapp/transport/graph/phone_test.go
@@ -1,0 +1,132 @@
+package graph
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	portstesting "github.com/diegoyosiura/whatsapp-sdk-go/internal/testutils/whatsapp/ports"
+)
+
+func TestNewPhoneAPI_DefaultBase(t *testing.T) {
+	a := NewPhoneAPI(&portstesting.FakeHTTPDoer{}, &portstesting.FakeTokenProvider{}, "v1", "waba", "")
+	if a.baseURL != DefaultBaseURL {
+		t.Fatalf("expected default base")
+	}
+}
+
+func TestPhoneAPI_List_AttachAuthError(t *testing.T) {
+	tp := &portstesting.FakeTokenProvider{Err: errors.New("no token")}
+	a := NewPhoneAPI(&portstesting.FakeHTTPDoer{}, tp, "v1", "waba", "")
+	if _, err := a.List(context.Background()); err == nil || !strings.Contains(err.Error(), "token:") {
+		t.Fatalf("expected token error, got %v", err)
+	}
+}
+
+func TestPhoneAPI_List_DoerError(t *testing.T) {
+	doer := &portstesting.FakeHTTPDoer{Fn: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("boom")
+	}}
+	tp := &portstesting.FakeTokenProvider{TokenValue: "t"}
+	a := NewPhoneAPI(doer, tp, "v1", "waba", "")
+	if _, err := a.List(context.Background()); err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected boom, got %v", err)
+	}
+}
+
+func TestPhoneAPI_List_Non2xx(t *testing.T) {
+	doer := &portstesting.FakeHTTPDoer{Fn: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		resp := &http.Response{StatusCode: 500, Body: io.NopCloser(strings.NewReader(`{"error":{"message":"x"}}`)), Header: make(http.Header), Request: req}
+		return resp, nil
+	}}
+	tp := &portstesting.FakeTokenProvider{TokenValue: "t"}
+	a := NewPhoneAPI(doer, tp, "v1", "waba", "")
+	if _, err := a.List(context.Background()); err == nil || !strings.Contains(err.Error(), "graph error") {
+		t.Fatalf("expected graph error, got %v", err)
+	}
+}
+
+func TestPhoneAPI_List_DecodeError(t *testing.T) {
+	doer := &portstesting.FakeHTTPDoer{Fn: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`notjson`)), Header: make(http.Header), Request: req}
+		return resp, nil
+	}}
+	tp := &portstesting.FakeTokenProvider{TokenValue: "t"}
+	a := NewPhoneAPI(doer, tp, "v1", "waba", "")
+	if _, err := a.List(context.Background()); err == nil || !strings.Contains(err.Error(), "decode phone list") {
+		t.Fatalf("expected decode error, got %v", err)
+	}
+}
+
+func TestPhoneAPI_List_Success(t *testing.T) {
+	body := `{"data":[{"id":"1","display_phone_number":"1"}]}`
+	doer := &portstesting.FakeHTTPDoer{Fn: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header), Request: req}
+		return resp, nil
+	}}
+	tp := &portstesting.FakeTokenProvider{TokenValue: "t"}
+	a := NewPhoneAPI(doer, tp, "v1", "waba", "")
+	out, err := a.List(context.Background())
+	if err != nil || len(out.Data) != 1 || out.Data[0].ID != "1" {
+		t.Fatalf("unexpected output %+v err %v", out, err)
+	}
+}
+
+func TestPhoneAPI_Get_AttachAuthError(t *testing.T) {
+	tp := &portstesting.FakeTokenProvider{Err: errors.New("no token")}
+	a := NewPhoneAPI(&portstesting.FakeHTTPDoer{}, tp, "v1", "waba", "")
+	if _, err := a.Get(context.Background(), "pn"); err == nil || !strings.Contains(err.Error(), "token:") {
+		t.Fatalf("expected token error, got %v", err)
+	}
+}
+
+func TestPhoneAPI_Get_DoerError(t *testing.T) {
+	doer := &portstesting.FakeHTTPDoer{Fn: func(ctx context.Context, req *http.Request) (*http.Response, error) { return nil, fmt.Errorf("boom") }}
+	tp := &portstesting.FakeTokenProvider{TokenValue: "t"}
+	a := NewPhoneAPI(doer, tp, "v1", "waba", "")
+	if _, err := a.Get(context.Background(), "pn"); err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected boom, got %v", err)
+	}
+}
+
+func TestPhoneAPI_Get_Non2xx(t *testing.T) {
+	doer := &portstesting.FakeHTTPDoer{Fn: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		resp := &http.Response{StatusCode: 404, Body: io.NopCloser(strings.NewReader(`{"error":{"message":"x"}}`)), Header: make(http.Header), Request: req}
+		return resp, nil
+	}}
+	tp := &portstesting.FakeTokenProvider{TokenValue: "t"}
+	a := NewPhoneAPI(doer, tp, "v1", "waba", "")
+	if _, err := a.Get(context.Background(), "pn"); err == nil || !strings.Contains(err.Error(), "graph error") {
+		t.Fatalf("expected graph error, got %v", err)
+	}
+}
+
+func TestPhoneAPI_Get_DecodeError(t *testing.T) {
+	doer := &portstesting.FakeHTTPDoer{Fn: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(`bad`)), Header: make(http.Header), Request: req}
+		return resp, nil
+	}}
+	tp := &portstesting.FakeTokenProvider{TokenValue: "t"}
+	a := NewPhoneAPI(doer, tp, "v1", "waba", "")
+	if _, err := a.Get(context.Background(), "pn"); err == nil || !strings.Contains(err.Error(), "decode phone") {
+		t.Fatalf("expected decode error, got %v", err)
+	}
+}
+
+func TestPhoneAPI_Get_Success(t *testing.T) {
+	body := `{"id":"pn","display_phone_number":"1"}`
+	doer := &portstesting.FakeHTTPDoer{Fn: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		resp := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header), Request: req}
+		return resp, nil
+	}}
+	tp := &portstesting.FakeTokenProvider{TokenValue: "t"}
+	a := NewPhoneAPI(doer, tp, "v1", "waba", "")
+	out, err := a.Get(context.Background(), "pn")
+	if err != nil || out.ID != "pn" {
+		t.Fatalf("unexpected output %v err %v", out, err)
+	}
+}

--- a/pkg/whatsapp/transport/graph/registration_test.go
+++ b/pkg/whatsapp/transport/graph/registration_test.go
@@ -1,0 +1,175 @@
+package graph
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	portstesting "github.com/diegoyosiura/whatsapp-sdk-go/internal/testutils/whatsapp/ports"
+	"github.com/diegoyosiura/whatsapp-sdk-go/pkg/whatsapp/domain"
+)
+
+func TestNewRegistrationAPI_DefaultBase(t *testing.T) {
+	a := NewRegistrationAPI(&portstesting.FakeHTTPDoer{}, &portstesting.FakeTokenProvider{}, "v1", "pn", "")
+	if a.baseURL != DefaultBaseURL {
+		t.Fatalf("expected default base")
+	}
+}
+
+func TestRegistrationAPI_endpoint(t *testing.T) {
+	a := NewRegistrationAPI(nil, nil, "v1", "pn", "https://g")
+	if got := a.endpoint("register"); got != "https://g/v1/pn/register" {
+		t.Fatalf("endpoint wrong: %s", got)
+	}
+	if got := a.endpoint(""); got != "https://g/v1/pn" {
+		t.Fatalf("endpoint empty wrong: %s", got)
+	}
+}
+
+func TestRegistrationAPI_RequestCode_AttachAuthErr(t *testing.T) {
+	tp := &portstesting.FakeTokenProvider{Err: errors.New("no token")}
+	a := NewRegistrationAPI(&portstesting.FakeHTTPDoer{}, tp, "v1", "pn", "")
+	_, err := a.RequestCode(context.Background(), domain.RequestCodeParams{CodeMethod: domain.CodeMethodSMS})
+	if err == nil || !strings.Contains(err.Error(), "token:") {
+		t.Fatalf("expected token error, got %v", err)
+	}
+}
+
+func TestRegistrationAPI_VerifyCode_AttachAuthErr(t *testing.T) {
+	tp := &portstesting.FakeTokenProvider{Err: errors.New("no token")}
+	a := NewRegistrationAPI(&portstesting.FakeHTTPDoer{}, tp, "v1", "pn", "")
+	_, err := a.VerifyCode(context.Background(), domain.VerifyCodeParams{Code: "1"})
+	if err == nil || !strings.Contains(err.Error(), "token:") {
+		t.Fatalf("expected token error, got %v", err)
+	}
+}
+
+func TestRegistrationAPI_Register_AttachAuthErr(t *testing.T) {
+	tp := &portstesting.FakeTokenProvider{Err: errors.New("no token")}
+	a := NewRegistrationAPI(&portstesting.FakeHTTPDoer{}, tp, "v1", "pn", "")
+	_, err := a.Register(context.Background(), domain.RegisterParams{})
+	if err == nil || !strings.Contains(err.Error(), "token:") {
+		t.Fatalf("expected token error, got %v", err)
+	}
+}
+
+func TestRegistrationAPI_Deregister_AttachAuthErr(t *testing.T) {
+	tp := &portstesting.FakeTokenProvider{Err: errors.New("no token")}
+	a := NewRegistrationAPI(&portstesting.FakeHTTPDoer{}, tp, "v1", "pn", "")
+	_, err := a.Deregister(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "token:") {
+		t.Fatalf("expected token error, got %v", err)
+	}
+}
+
+func TestRegistrationAPI_SetTwoStep_AttachAuthErr(t *testing.T) {
+	tp := &portstesting.FakeTokenProvider{Err: errors.New("no token")}
+	a := NewRegistrationAPI(&portstesting.FakeHTTPDoer{}, tp, "v1", "pn", "")
+	_, err := a.SetTwoStep(context.Background(), domain.TwoStepParams{Pin: "1"})
+	if err == nil || !strings.Contains(err.Error(), "token:") {
+		t.Fatalf("expected token error, got %v", err)
+	}
+}
+
+func newRegistrationAPISuccess(fn func(ctx context.Context, req *http.Request) (*http.Response, error)) *RegistrationAPI {
+	doer := &portstesting.FakeHTTPDoer{Fn: fn}
+	tp := &portstesting.FakeTokenProvider{TokenValue: "t"}
+	return NewRegistrationAPI(doer, tp, "v1", "pn", "")
+}
+
+func successResponse(req *http.Request, body string) *http.Response {
+	return &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body)), Header: make(http.Header), Request: req}
+}
+
+func TestRegistrationAPI_RequestCode_Success(t *testing.T) {
+	a := newRegistrationAPISuccess(func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		return successResponse(req, `{"success":true}`), nil
+	})
+	out, err := a.RequestCode(context.Background(), domain.RequestCodeParams{CodeMethod: domain.CodeMethodSMS})
+	if err != nil || !out.Success {
+		t.Fatalf("unexpected %v %v", out, err)
+	}
+}
+
+func TestRegistrationAPI_VerifyCode_Success(t *testing.T) {
+	a := newRegistrationAPISuccess(func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		return successResponse(req, `{"success":true}`), nil
+	})
+	out, err := a.VerifyCode(context.Background(), domain.VerifyCodeParams{Code: "123"})
+	if err != nil || !out.Success {
+		t.Fatalf("unexpected %v %v", out, err)
+	}
+}
+
+func TestRegistrationAPI_Register_Success(t *testing.T) {
+	a := newRegistrationAPISuccess(func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		b, _ := io.ReadAll(req.Body)
+		if !strings.Contains(string(b), "pin") {
+			t.Fatalf("expected pin in body: %s", string(b))
+		}
+		return successResponse(req, `{"success":true}`), nil
+	})
+	pin := "1234"
+	out, err := a.Register(context.Background(), domain.RegisterParams{Pin: &pin})
+	if err != nil || !out.Success {
+		t.Fatalf("unexpected %v %v", out, err)
+	}
+}
+
+func TestRegistrationAPI_Deregister_Success(t *testing.T) {
+	a := newRegistrationAPISuccess(func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		return successResponse(req, `{"success":true}`), nil
+	})
+	out, err := a.Deregister(context.Background())
+	if err != nil || !out.Success {
+		t.Fatalf("unexpected %v %v", out, err)
+	}
+}
+
+func TestRegistrationAPI_SetTwoStep_Success(t *testing.T) {
+	a := newRegistrationAPISuccess(func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		return successResponse(req, `{"success":true}`), nil
+	})
+	out, err := a.SetTwoStep(context.Background(), domain.TwoStepParams{Pin: "222"})
+	if err != nil || !out.Success {
+		t.Fatalf("unexpected %v %v", out, err)
+	}
+}
+
+func TestRegistrationAPI_decodeActionResult_DoerError(t *testing.T) {
+	doer := &portstesting.FakeHTTPDoer{Fn: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("boom")
+	}}
+	a := NewRegistrationAPI(doer, &portstesting.FakeTokenProvider{}, "v1", "pn", "")
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://x", nil)
+	if _, err := a.decodeActionResult(req); err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected boom, got %v", err)
+	}
+}
+
+func TestRegistrationAPI_decodeActionResult_DecodeError(t *testing.T) {
+	doer := &portstesting.FakeHTTPDoer{Fn: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		return successResponse(req, `bad`), nil
+	}}
+	a := NewRegistrationAPI(doer, &portstesting.FakeTokenProvider{}, "v1", "pn", "")
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://x", nil)
+	if _, err := a.decodeActionResult(req); err == nil || !strings.Contains(err.Error(), "decode success") {
+		t.Fatalf("expected decode error, got %v", err)
+	}
+}
+
+func TestRegistrationAPI_decodeActionResult_GraphError(t *testing.T) {
+	doer := &portstesting.FakeHTTPDoer{Fn: func(ctx context.Context, req *http.Request) (*http.Response, error) {
+		resp := &http.Response{StatusCode: 400, Body: io.NopCloser(strings.NewReader(`{"error":{"message":"x"}}`)), Header: make(http.Header), Request: req}
+		return resp, nil
+	}}
+	a := NewRegistrationAPI(doer, &portstesting.FakeTokenProvider{}, "v1", "pn", "")
+	req, _ := http.NewRequestWithContext(context.Background(), http.MethodPost, "https://x", nil)
+	if _, err := a.decodeActionResult(req); err == nil || !strings.Contains(err.Error(), "graph error") {
+		t.Fatalf("expected graph error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for Graph transport endpoint builders and message API
- exercise Phone and Registration APIs across success and error paths
